### PR TITLE
Fix client component error

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- mark the home page as a client component

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e9cb33c8328922f9dcfed0b3a5d