### PR TITLE
Add wallet connection and Base network support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Address of your deployed TokenBundleFactory on Base Sepolia
+NEXT_PUBLIC_FACTORY_ADDRESS=

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
+!.env.example
 .env*
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -26,4 +26,10 @@ npx hardhat test
 
 ## Environment
 
-`NEXT_PUBLIC_FACTORY_ADDRESS` should point to a deployed `TokenBundleFactory` when interacting with the app.
+Create a `.env.local` file containing the address of a deployed `TokenBundleFactory` on Base Sepolia:
+
+```bash
+NEXT_PUBLIC_FACTORY_ADDRESS=0xYourFactoryAddress
+```
+
+Restart the dev server after adding the file.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,15 @@
 
 import { useState } from "react";
 import { useWriteContract } from "wagmi";
+import ConnectButton from "@/components/ConnectButton";
 import factoryAbi from "@/abi/TokenBundleFactory.json";
 import bundleAbi from "@/abi/TokenBundle.json";
 
 export default function Home() {
   const [name, setName] = useState("");
   const [tokens, setTokens] = useState("");
-  const [usdc, setUsdc] = useState("");
+  const [usdcAmount, setUsdcAmount] = useState("");
+  const [usdcAddress, setUsdcAddress] = useState("");
   const [bundle, setBundle] = useState<string | null>(null);
 
   const { writeContractAsync } = useWriteContract();
@@ -22,7 +24,13 @@ export default function Home() {
       abi: factoryAbi,
       address: process.env.NEXT_PUBLIC_FACTORY_ADDRESS as `0x${string}`,
       functionName: "createBundle",
-      args: [name, name.slice(0, 3).toUpperCase(), "0x", list, weights],
+      args: [
+        name,
+        name.slice(0, 3).toUpperCase(),
+        usdcAddress as `0x${string}`,
+        list,
+        weights,
+      ],
     });
     // address of new bundle is returned
     setBundle(result as unknown as string);
@@ -35,12 +43,13 @@ export default function Home() {
       abi: bundleAbi,
       address: bundle as `0x${string}`,
       functionName: "deposit",
-      args: [BigInt(usdc)],
+      args: [BigInt(usdcAmount)],
     });
   };
 
   return (
     <main className="p-8 flex flex-col gap-8">
+      <ConnectButton />
       <div>
         <h1 className="text-2xl font-semibold mb-4">Create bundle</h1>
         <form onSubmit={handleCreate} className="flex flex-col gap-2 max-w-sm">
@@ -56,6 +65,12 @@ export default function Home() {
             placeholder="Token addresses (comma separated)"
             className="border p-2"
           />
+          <input
+            value={usdcAddress}
+            onChange={(e) => setUsdcAddress(e.target.value)}
+            placeholder="USDC address"
+            className="border p-2"
+          />
           <button className="bg-blue-500 text-white p-2" type="submit">
             Create
           </button>
@@ -66,8 +81,8 @@ export default function Home() {
         <h2 className="text-xl font-semibold mb-4">Deposit USDC</h2>
         <form onSubmit={handleDeposit} className="flex flex-col gap-2 max-w-sm">
           <input
-            value={usdc}
-            onChange={(e) => setUsdc(e.target.value)}
+            value={usdcAmount}
+            onChange={(e) => setUsdcAmount(e.target.value)}
             placeholder="Amount"
             className="border p-2"
           />

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useAccount, useConnect, useDisconnect } from "wagmi";
+
+export default function ConnectButton() {
+  const { connect, connectors } = useConnect();
+  const { disconnect } = useDisconnect();
+  const { isConnected, address } = useAccount();
+
+  if (isConnected)
+    return (
+      <div className="flex items-center gap-2">
+        <span className="truncate">{address}</span>
+        <button
+          onClick={() => disconnect()}
+          className="bg-gray-200 p-2"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+
+  return (
+    <button
+      onClick={() => connect({ connector: connectors[0] })}
+      className="bg-blue-500 text-white p-2"
+    >
+      Connect Wallet
+    </button>
+  );
+}

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,9 +1,11 @@
-import { createConfig, http } from 'wagmi';
-import { hardhat } from 'wagmi/chains';
+import { createConfig, http } from 'wagmi'
+import { injected } from 'wagmi/connectors'
+import { baseSepolia } from 'wagmi/chains'
 
 export const config = createConfig({
-  chains: [hardhat],
+  chains: [baseSepolia],
   transports: {
-    [hardhat.id]: http('http://localhost:8545'),
+    [baseSepolia.id]: http(),
   },
-});
+  connectors: [injected()],
+})


### PR DESCRIPTION
## Summary
- configure wagmi to use Base Sepolia and an injected connector
- add wallet connect/disconnect button
- allow entering USDC token address
- document environment variable setup and provide an example file
- allow committing `.env.example`

## Testing
- `npm run lint`
- `npx hardhat test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684a9c9074808328ba4763f91af47dc1